### PR TITLE
Tune project's formatter

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.js]
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ data: `http://localhost:9000/measurements`
 ## A tech stack
 
 *   Backend: Spring Boot, Lombok, Java 8 (considering JDK 11), Mapstruct,
+
 *   Frontend: it's not yet decided (it's gonna be some popular 
 and lightweight JS framework supported by GWT JsInterop or J2CL 
 for transpiling Java to JavaScript). 
@@ -28,7 +29,7 @@ checkbox is ticked under:
 Preferences → Compiler → Annotation Processors, as it is described 
 [here](https://stackoverflow.com/questions/14866765/building-with-lomboks-slf4j-and-intellij-cannot-find-symbol-log).
 
-## Projects maintenance
+## Project's maintenance
 
 The project contains also bunch of tools helping in maintenance like:
 

--- a/backend/src/main/java/pl/itrack/airqeye/store/StoreApplication.java
+++ b/backend/src/main/java/pl/itrack/airqeye/store/StoreApplication.java
@@ -11,20 +11,20 @@ import java.util.Locale;
 @EnableFeignClients
 public class StoreApplication {
 
-	public static void main(String... args) {
-		configureLocale();
-		runApplication(args);
-	}
+    public static void main(String... args) {
+        configureLocale();
+        runApplication(args);
+    }
 
-	/**
-	 * Configures JVM and Spring to use defined local over OS one.
-	 */
-	private static void configureLocale() {
-		Locale.setDefault(Locale.US);
-		LocaleContextHolder.setDefaultLocale(Locale.US);
-	}
+    /**
+     * Configures JVM and Spring to use defined local over OS one.
+     */
+    private static void configureLocale() {
+        Locale.setDefault(Locale.US);
+        LocaleContextHolder.setDefaultLocale(Locale.US);
+    }
 
-	private static void runApplication(String[] args) {
-		SpringApplication.run(StoreApplication.class, args);
-	}
+    private static void runApplication(String[] args) {
+        SpringApplication.run(StoreApplication.class, args);
+    }
 }

--- a/backend/src/main/java/pl/itrack/airqeye/store/dataclient/luftdaten/LuftdatenClient.java
+++ b/backend/src/main/java/pl/itrack/airqeye/store/dataclient/luftdaten/LuftdatenClient.java
@@ -12,14 +12,14 @@ import java.util.List;
 
 @Component
 @FeignClient(name = "supplier-luftdaten",
-        decode404 = true,
-        url = "${supplier-luftdaten.url}")
+    decode404 = true,
+    url = "${supplier-luftdaten.url}")
 public interface LuftdatenClient {
 
     @RequestMapping(value = "/static/v2/data.dust.min.json",
-            method = RequestMethod.GET,
-            produces = {
-                    MediaType.APPLICATION_JSON_VALUE
-            })
+        method = RequestMethod.GET,
+        produces = {
+            MediaType.APPLICATION_JSON_VALUE
+        })
     ResponseEntity<List<LuftdatenMeasurement>> retrieveData();
 }

--- a/backend/src/main/java/pl/itrack/airqeye/store/dataclient/luftdaten/config/SupportedDataTypesHelper.java
+++ b/backend/src/main/java/pl/itrack/airqeye/store/dataclient/luftdaten/config/SupportedDataTypesHelper.java
@@ -11,7 +11,7 @@ public class SupportedDataTypesHelper {
      * https://github.com/opendata-stuttgart/feinstaub-map-v2/blob/master/src/js/feinstaub-api.js
      */
     public static final List<String> SUPPORTED_SENSORS =
-            asList("SDS011", "SDS021", "PMS1003", "PMS3003", "PMS5003", "PMS6003", "PMS7003", "HPM", "SPS30");
+        asList("SDS011", "SDS021", "PMS1003", "PMS3003", "PMS5003", "PMS6003", "PMS7003", "HPM", "SPS30");
 
     /**
      * Type names as provided by Luftdaten: https://maps.luftdaten.info/data/v2/data.dust.min.json data source.

--- a/backend/src/main/java/pl/itrack/airqeye/store/dataclient/luftdaten/mapper/AddressMapper.java
+++ b/backend/src/main/java/pl/itrack/airqeye/store/dataclient/luftdaten/mapper/AddressMapper.java
@@ -9,7 +9,8 @@ import pl.itrack.airqeye.store.measurement.entity.Address;
 @Mapper(config = DefaultMapperConfig.class)
 interface AddressMapper {
 
-    @Mapping(target = "province", ignore = true) // not provided by Luftdaten
-    @Mapping(target = "additionalAddressDetails", ignore = true)  // not provided by Luftdaten
+    // the ignored ones are not provided by Luftdaten
+    @Mapping(target = "province", ignore = true)
+    @Mapping(target = "additionalAddressDetails", ignore = true)
     Address fromDto(Location location);
 }

--- a/backend/src/main/java/pl/itrack/airqeye/store/dataclient/luftdaten/mapper/InstallationMapper.java
+++ b/backend/src/main/java/pl/itrack/airqeye/store/dataclient/luftdaten/mapper/InstallationMapper.java
@@ -7,7 +7,7 @@ import pl.itrack.airqeye.store.measurement.entity.Installation;
 import pl.itrack.airqeye.store.measurement.mapper.DefaultMapperConfig;
 
 @Mapper(config = DefaultMapperConfig.class,
-        uses = {LocationMapper.class, AddressMapper.class, SensorMapper.class})
+    uses = {LocationMapper.class, AddressMapper.class, SensorMapper.class})
 interface InstallationMapper {
 
     @Mapping(target = "id", ignore = true)

--- a/backend/src/main/java/pl/itrack/airqeye/store/dataclient/luftdaten/mapper/MeasurementMapper.java
+++ b/backend/src/main/java/pl/itrack/airqeye/store/dataclient/luftdaten/mapper/MeasurementMapper.java
@@ -22,7 +22,7 @@ import static pl.itrack.airqeye.store.dataclient.luftdaten.config.SupportedDataT
 import static pl.itrack.airqeye.store.dataclient.luftdaten.config.SupportedDataTypesHelper.SUPPORTED_SENSORS;
 
 @Mapper(config = DefaultMapperConfig.class,
-        uses = {MeasurementValueMapper.class, InstallationMapper.class})
+    uses = {MeasurementValueMapper.class, InstallationMapper.class})
 public interface MeasurementMapper {
 
     String DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
@@ -52,16 +52,16 @@ public interface MeasurementMapper {
         List<LuftdatenMeasurement> validData = getValidData(data);
 
         return validData
-                .stream()
-                .map(this::fromDto)
-                .collect(Collectors.toCollection(() -> new ArrayList<>(validData.size())));
+            .stream()
+            .map(this::fromDto)
+            .collect(Collectors.toCollection(() -> new ArrayList<>(validData.size())));
     }
 
     default List<LuftdatenMeasurement> getValidData(List<LuftdatenMeasurement> data) {
         return data.stream()
-                .filter(WITH_SUPPORTED_COUNTRIES
-                        .and(WITH_SUPPORTED_SENSORS)
-                        .and(WITH_SUPPORTED_VALUE_TYPES))
-                .collect(Collectors.toList());
+            .filter(WITH_SUPPORTED_COUNTRIES
+                .and(WITH_SUPPORTED_SENSORS)
+                .and(WITH_SUPPORTED_VALUE_TYPES))
+            .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/pl/itrack/airqeye/store/dataclient/luftdaten/mapper/MeasurementValueMapper.java
+++ b/backend/src/main/java/pl/itrack/airqeye/store/dataclient/luftdaten/mapper/MeasurementValueMapper.java
@@ -28,10 +28,10 @@ interface MeasurementValueMapper {
     double THRESHOLD_PM25 = 900d;
 
     Predicate<SensorData> WITH_PM10_RESPECTING_THRESHOLD =
-            data -> MEASUREMENT_TYPE_PM10.equals(data.getValueType()) && data.getValue() < THRESHOLD_PM10;
+        data -> MEASUREMENT_TYPE_PM10.equals(data.getValueType()) && data.getValue() < THRESHOLD_PM10;
 
     Predicate<SensorData> WITH_PM25_RESPECTING_THRESHOLD =
-            data -> MEASUREMENT_TYPE_PM2_5.equals(data.getValueType()) && data.getValue() < THRESHOLD_PM25;
+        data -> MEASUREMENT_TYPE_PM2_5.equals(data.getValueType()) && data.getValue() < THRESHOLD_PM25;
 
     /**
      * Convert original Lufdaten measurement value to the AirQ Monitor supported structure.
@@ -77,8 +77,8 @@ interface MeasurementValueMapper {
         }
 
         return sensorData.stream()
-                .filter(WITH_PM10_RESPECTING_THRESHOLD.or(WITH_PM25_RESPECTING_THRESHOLD))
-                .map(this::fromDto)
-                .collect(toList());
+            .filter(WITH_PM10_RESPECTING_THRESHOLD.or(WITH_PM25_RESPECTING_THRESHOLD))
+            .map(this::fromDto)
+            .collect(toList());
     }
 }

--- a/backend/src/main/java/pl/itrack/airqeye/store/dataclient/luftdaten/service/LuftdatenService.java
+++ b/backend/src/main/java/pl/itrack/airqeye/store/dataclient/luftdaten/service/LuftdatenService.java
@@ -45,7 +45,7 @@ public class LuftdatenService implements HasUpdatableDataFeed {
     private boolean isUpdateRequired() {
         LocalDateTime lastUpdateUtc = measurementService.getLatestUpdate(Supplier.LUFTDATEN);
         return LocalDateTime.now(ZoneOffset.UTC)
-                .isAfter(lastUpdateUtc.plusMinutes(updateFrequencyInMinutes));
+            .isAfter(lastUpdateUtc.plusMinutes(updateFrequencyInMinutes));
     }
 
     /**

--- a/backend/src/main/java/pl/itrack/airqeye/store/measurement/InstallationNotFoundAdvice.java
+++ b/backend/src/main/java/pl/itrack/airqeye/store/measurement/InstallationNotFoundAdvice.java
@@ -9,14 +9,14 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import pl.itrack.airqeye.store.measurement.service.InstallationNotFoundException;
 
 @RestControllerAdvice
-class InstallationNotFoundAdvice {
+public class InstallationNotFoundAdvice {
 
     @ExceptionHandler(InstallationNotFoundException.class)
-    ResponseEntity<ErrorMessage> installationNotFoundHandler(InstallationNotFoundException exception) {
+    public ResponseEntity<ErrorMessage> installationNotFoundHandler(InstallationNotFoundException exception) {
         return ResponseEntity
-                .status(HttpStatus.NOT_FOUND)
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(new ErrorMessage(exception.getMessage()));
+            .status(HttpStatus.NOT_FOUND)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(new ErrorMessage(exception.getMessage()));
     }
 
     @Value

--- a/backend/src/main/java/pl/itrack/airqeye/store/measurement/MeasurementsController.java
+++ b/backend/src/main/java/pl/itrack/airqeye/store/measurement/MeasurementsController.java
@@ -41,8 +41,7 @@ public class MeasurementsController {
      * Provides the latest measurements related to given supplier's installation
      *
      * @param supplierInstallationId - supplier's installation id
-     * @param supplier - supplier indication
-     *
+     * @param supplier               - supplier indication
      * @return the latest measurements related to given installation
      */
     @GetMapping(URI_SELECTED_MEASUREMENTS)

--- a/backend/src/main/java/pl/itrack/airqeye/store/measurement/entity/Installation.java
+++ b/backend/src/main/java/pl/itrack/airqeye/store/measurement/entity/Installation.java
@@ -38,17 +38,17 @@ public class Installation {
 
     @Embedded
     @AttributeOverrides({
-            @AttributeOverride(name = "latitude", column = @Column(name = "LATITUDE")),
-            @AttributeOverride(name = "longitude", column = @Column(name = "LONGITUDE")),
-            @AttributeOverride(name = "elevation", column = @Column(name = "ELEVATION"))
+        @AttributeOverride(name = "latitude", column = @Column(name = "LATITUDE")),
+        @AttributeOverride(name = "longitude", column = @Column(name = "LONGITUDE")),
+        @AttributeOverride(name = "elevation", column = @Column(name = "ELEVATION"))
     })
     private Location location;
 
     @Embedded
     @AttributeOverrides({
-            @AttributeOverride(name = "country", column = @Column(name = "COUNTRY")),
-            @AttributeOverride(name = "province", column = @Column(name = "PROVINCE")),
-            @AttributeOverride(name = "additionalAddressDetails", column = @Column(name = "ADDITIONAL_ADDRESS_DETAILS"))
+        @AttributeOverride(name = "country", column = @Column(name = "COUNTRY")),
+        @AttributeOverride(name = "province", column = @Column(name = "PROVINCE")),
+        @AttributeOverride(name = "additionalAddressDetails", column = @Column(name = "ADDITIONAL_ADDRESS_DETAILS"))
     })
     private Address address;
 

--- a/backend/src/main/java/pl/itrack/airqeye/store/measurement/enumeration/MeasurementType.java
+++ b/backend/src/main/java/pl/itrack/airqeye/store/measurement/enumeration/MeasurementType.java
@@ -5,10 +5,6 @@
  */
 package pl.itrack.airqeye.store.measurement.enumeration;
 
-/**
- *
- * @author msx
- */
 public enum MeasurementType {
     PM1, PM25, PM10, PRESSURE, HUMIDITY, TEMPERATURE
 }

--- a/backend/src/main/java/pl/itrack/airqeye/store/measurement/mapper/DefaultMapperConfig.java
+++ b/backend/src/main/java/pl/itrack/airqeye/store/measurement/mapper/DefaultMapperConfig.java
@@ -7,10 +7,10 @@ import org.mapstruct.ReportingPolicy;
 
 
 @MapperConfig(
-        unmappedTargetPolicy = ReportingPolicy.ERROR,
-        componentModel = "spring",
-        injectionStrategy = InjectionStrategy.CONSTRUCTOR,
-        nullValueMappingStrategy = NullValueMappingStrategy.RETURN_NULL
+    unmappedTargetPolicy = ReportingPolicy.ERROR,
+    componentModel = "spring",
+    injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+    nullValueMappingStrategy = NullValueMappingStrategy.RETURN_NULL
 )
 public class DefaultMapperConfig {
 }

--- a/backend/src/main/java/pl/itrack/airqeye/store/measurement/service/MeasurementService.java
+++ b/backend/src/main/java/pl/itrack/airqeye/store/measurement/service/MeasurementService.java
@@ -23,15 +23,15 @@ public class MeasurementService {
     @Transactional(readOnly = true)
     public List<Measurement> retrieveMeasurements() {
         return installationRepository.findAll().stream()
-                .map(Installation::getMeasurements)
-                .flatMap(Collection::stream)
-                .collect(Collectors.toList());
+            .map(Installation::getMeasurements)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
     public List<Measurement> retrieveMeasurements(final Long installationId, Supplier supplier) {
         Installation installation = installationRepository.findByProvider(supplier, installationId)
-                .orElseThrow(() -> new InstallationNotFoundException(installationId));
+            .orElseThrow(() -> new InstallationNotFoundException(installationId));
 
         return installation.getMeasurements();
     }
@@ -46,8 +46,8 @@ public class MeasurementService {
 
     private List<Installation> getInstallations(List<Measurement> measurements) {
         return measurements.stream()
-                .map(Measurement::getInstallation)
-                .collect(Collectors.toList());
+            .map(Measurement::getInstallation)
+            .collect(Collectors.toList());
     }
 
     @Transactional
@@ -55,7 +55,7 @@ public class MeasurementService {
         // FIXME: modify to delete by IDs in batch in partitions
         //  or try to implement delete with where clause by enum
         installationRepository.findByProvider(dataProvider)
-                .forEach(installation -> installationRepository.deleteById(installation.getId()));
+            .forEach(installation -> installationRepository.deleteById(installation.getId()));
     }
 
     public LocalDateTime getLatestUpdate(Supplier dataProvider) {

--- a/backend/src/test/java/pl/itrack/airqeye/store/MeasurementTestDataBuilder.java
+++ b/backend/src/test/java/pl/itrack/airqeye/store/MeasurementTestDataBuilder.java
@@ -25,15 +25,15 @@ public class MeasurementTestDataBuilder {
         final MeasurementValue measurementValue2 = getMeasurementValue(MeasurementType.PM25, 11.55);
 
         return Measurement.builder()
-                .occurredAtUtc(occurredAt)
-                .measurementValues(asList(measurementValue1, measurementValue2));
+            .occurredAtUtc(occurredAt)
+            .measurementValues(asList(measurementValue1, measurementValue2));
     }
 
     private static MeasurementValue getMeasurementValue(MeasurementType type, double value) {
         return MeasurementValue.builder()
-                .type(type)
-                .value(value)
-                .build();
+            .type(type)
+            .value(value)
+            .build();
     }
 
     public static Installation.InstallationBuilder prebuildInstallation(Supplier supplier) {
@@ -42,22 +42,22 @@ public class MeasurementTestDataBuilder {
 
     public static Installation.InstallationBuilder prebuildInstallation(Supplier supplier, Long supplierInstallationId) {
         Address address = Address.builder()
-                .country(Country.PL)
-                .province(Province.POMORSKIE)
-                .additionalAddressDetails("ul. Testowa 4B, Gdańsk") // np. Airly podaje
-                .build();
+            .country(Country.PL)
+            .province(Province.POMORSKIE)
+            .additionalAddressDetails("ul. Testowa 4B, Gdańsk") // np. Airly podaje
+            .build();
 
         Sensor sensor = Sensor.builder()
-                .supplierSensorId(323L)
-                .manufacturer("Nova Fitness")
-                .description("SDS011") // name
-                .build();
+            .supplierSensorId(323L)
+            .manufacturer("Nova Fitness")
+            .description("SDS011") // name
+            .build();
 
         return Installation.builder()
-                .location(Location.builder().latitude(51.094).longitude(17.002).elevation(124).build())
-                .address(address)
-                .supplier(supplier)
-                .supplierInstallationId(supplierInstallationId)
-                .sensor(sensor);
+            .location(Location.builder().latitude(51.094).longitude(17.002).elevation(124).build())
+            .address(address)
+            .supplier(supplier)
+            .supplierInstallationId(supplierInstallationId)
+            .sensor(sensor);
     }
 }

--- a/backend/src/test/java/pl/itrack/airqeye/store/MeasurementsControllerITest.java
+++ b/backend/src/test/java/pl/itrack/airqeye/store/MeasurementsControllerITest.java
@@ -55,10 +55,10 @@ public class MeasurementsControllerITest {
     private static final String URI_SELECTED_MEASUREMENTS = "/measurements/%s/%d";
 
     private static final List<String> SUPPORTED_SENSORS =
-            asList("SDS011", "SDS021", "PMS1003", "PMS3003", "PMS5003", "PMS6003", "PMS7003", "HPM", "SPS30");
+        asList("SDS011", "SDS021", "PMS1003", "PMS3003", "PMS5003", "PMS6003", "PMS7003", "HPM", "SPS30");
 
     private static final List<MeasurementType> SUPPORTED_MEASUREMENT_TYPES =
-            asList(MeasurementType.PM10, MeasurementType.PM25);
+        asList(MeasurementType.PM10, MeasurementType.PM25);
 
     private ObjectMapper objectMapper = Jackson2ObjectMapperBuilder.json().build();
 
@@ -112,21 +112,21 @@ public class MeasurementsControllerITest {
 
     private Set<String> getUsedSensorTypes(List<Measurement> data) {
         return data.stream()
-                .map(entry -> entry.getInstallation().getSensor().getDescription())
-                .collect(Collectors.toSet());
+            .map(entry -> entry.getInstallation().getSensor().getDescription())
+            .collect(Collectors.toSet());
     }
 
     private Set<MeasurementType> getUsedMeasurementTypes(List<Measurement> data) {
         return data.stream()
-                .flatMap(entry -> entry.getMeasurementValues().stream())
-                .map(MeasurementValue::getType)
-                .collect(Collectors.toSet());
+            .flatMap(entry -> entry.getMeasurementValues().stream())
+            .map(MeasurementValue::getType)
+            .collect(Collectors.toSet());
     }
 
     private long countMeasurementsWithSupportedTypes(List<Measurement> data) {
         return data.stream()
-                .map(entry -> SUPPORTED_MEASUREMENT_TYPES.containsAll(asValueTypes(entry.getMeasurementValues())))
-                .count();
+            .map(entry -> SUPPORTED_MEASUREMENT_TYPES.containsAll(asValueTypes(entry.getMeasurementValues())))
+            .count();
     }
 
     private List<MeasurementType> asValueTypes(List<MeasurementValue> values) {
@@ -155,11 +155,11 @@ public class MeasurementsControllerITest {
     private void createTestDataWithOneInstallation(Long installationId) {
         repository.deleteAll();
         final Measurement measurement =
-                prebuildMeasurement(LocalDateTime.now().minusYears(5))
-                        .installation(prebuildInstallation(Supplier.LUFTDATEN)
-                                .supplierInstallationId(installationId)
-                                .build())
-                        .build();
+            prebuildMeasurement(LocalDateTime.now().minusYears(5))
+                .installation(prebuildInstallation(Supplier.LUFTDATEN)
+                    .supplierInstallationId(installationId)
+                    .build())
+                .build();
         repository.save(measurement.getInstallation());
         repository.flush();
     }

--- a/backend/src/test/java/pl/itrack/airqeye/store/dataclient/luftdaten/mapper/LuftdatenDataSourceRecursiveMappingTest.java
+++ b/backend/src/test/java/pl/itrack/airqeye/store/dataclient/luftdaten/mapper/LuftdatenDataSourceRecursiveMappingTest.java
@@ -24,7 +24,7 @@ class LuftdatenDataSourceRecursiveMappingTest {
 
     private static final String MEASUREMENT_DATE = "2019-09-29 07:51:04";
     private static final LocalDateTime RESPECTIVE_PARSED_MEASUREMENT_DATE
-            = LocalDateTime.of(2019, 9, 29, 7, 51, 4);
+        = LocalDateTime.of(2019, 9, 29, 7, 51, 4);
     private static final double ALTITUDE = 124d;
     private static final Country COUNTRY = Country.PL;
     private static final double LATITUDE = 51.094d;
@@ -104,31 +104,31 @@ class LuftdatenDataSourceRecursiveMappingTest {
 
     private LuftdatenMeasurement getLuftdatenMeasurement(String country, String measurementDate) {
         return LuftdatenMeasurement.builder()
-                .id(5017918083L)
-                .timestampUtc(measurementDate)
-                .location(Location.builder()
-                        .id(LOCATION_ID)
-                        .latitude(LATITUDE)
-                        .longitude(LONGITUDE)
-                        .altitude(ALTITUDE)
-                        .country(country)
-                        .build())
-                .sensor(Sensor.builder()
-                        .id(SENSOR_ID)
-                        .type(SensorType.of(1L, SENSOR_MANUFACTURER, SENSOR_NAME))
-                        .build())
-                .sensorData(asList(
-                        SensorData.of(10652023377L, SENSOR_VALUE_1, SENSOR_TYPE_1),
-                        SensorData.of(10652023398L, SENSOR_VALUE_2, SENSOR_TYPE_2)))
-                .build();
+            .id(5017918083L)
+            .timestampUtc(measurementDate)
+            .location(Location.builder()
+                .id(LOCATION_ID)
+                .latitude(LATITUDE)
+                .longitude(LONGITUDE)
+                .altitude(ALTITUDE)
+                .country(country)
+                .build())
+            .sensor(Sensor.builder()
+                .id(SENSOR_ID)
+                .type(SensorType.of(1L, SENSOR_MANUFACTURER, SENSOR_NAME))
+                .build())
+            .sensorData(asList(
+                SensorData.of(10652023377L, SENSOR_VALUE_1, SENSOR_TYPE_1),
+                SensorData.of(10652023398L, SENSOR_VALUE_2, SENSOR_TYPE_2)))
+            .build();
     }
 
     @Test
     void handleMultipleEntries() {
         // Given
         final List<LuftdatenMeasurement> luftdatenFeed = asList(
-                getSampleLuftdatenResponse(Country.PL.toString()),
-                getSampleLuftdatenResponse(Country.DE.toString()));
+            getSampleLuftdatenResponse(Country.PL.toString()),
+            getSampleLuftdatenResponse(Country.DE.toString()));
 
         // When
         final List<Measurement> result = measurementMapper.fromDtos(luftdatenFeed);
@@ -144,8 +144,8 @@ class LuftdatenDataSourceRecursiveMappingTest {
     void ignoreUnsupportedCountry() {
         // Given
         final List<LuftdatenMeasurement> luftdatenFeed = asList(
-                getSampleLuftdatenResponse("XX"),
-                getSampleLuftdatenResponse(Country.PL.toString()));
+            getSampleLuftdatenResponse("XX"),
+            getSampleLuftdatenResponse(Country.PL.toString()));
 
         // When
         final List<Measurement> result = measurementMapper.fromDtos(luftdatenFeed);

--- a/backend/src/test/java/pl/itrack/airqeye/store/dataclient/luftdaten/mapper/MeasurementMapperTest.java
+++ b/backend/src/test/java/pl/itrack/airqeye/store/dataclient/luftdaten/mapper/MeasurementMapperTest.java
@@ -38,7 +38,7 @@ class MeasurementMapperTest {
     private static final String SUPPORTED_VALUE_TYPE = "P1";
     private static final String MEASUREMENT_DATE = "2019-09-29 07:51:04";
     private static final LocalDateTime RESPECTIVE_PARSED_MEASUREMENT_DATE
-            = LocalDateTime.of(2019, 9, 29, 7, 51, 4);
+        = LocalDateTime.of(2019, 9, 29, 7, 51, 4);
 
     private InstallationMapper installationMapper;
 
@@ -61,7 +61,7 @@ class MeasurementMapperTest {
     void handleSupportedData() {
         // Given
         List<LuftdatenMeasurement> source = Collections.singletonList(
-                getLuftdatenDataSample(Country.PL.toString(), SUPPORTED_SENSOR_TYPE, SUPPORTED_VALUE_TYPE));
+            getLuftdatenDataSample(Country.PL.toString(), SUPPORTED_SENSOR_TYPE, SUPPORTED_VALUE_TYPE));
 
         // When
         final List<Measurement> target = measurementMapper.fromDtos(source);
@@ -79,11 +79,11 @@ class MeasurementMapperTest {
         Sensor sensor = Sensor.builder().type(SensorType.builder().name(sensorType).build()).build();
 
         return LuftdatenMeasurement.builder()
-                .id(123L)
-                .location(location)
-                .timestampUtc(MEASUREMENT_DATE)
-                .sensor(sensor)
-                .sensorData(Collections.singletonList(SensorData.builder().valueType(valueType).value(123d).build())).build();
+            .id(123L)
+            .location(location)
+            .timestampUtc(MEASUREMENT_DATE)
+            .sensor(sensor)
+            .sensorData(Collections.singletonList(SensorData.builder().valueType(valueType).value(123d).build())).build();
     }
 
     @Test
@@ -91,9 +91,9 @@ class MeasurementMapperTest {
     void ignoreUnsupportedCountry() {
         // Given
         List<LuftdatenMeasurement> source = Arrays.asList(
-                getLuftdatenDataSample(Country.NL.toString(), SUPPORTED_SENSOR_TYPE, SUPPORTED_VALUE_TYPE),
-                getLuftdatenDataSample("XX", SUPPORTED_SENSOR_TYPE, SUPPORTED_VALUE_TYPE),
-                getLuftdatenDataSample(Country.PL.toString(), SUPPORTED_SENSOR_TYPE, SUPPORTED_VALUE_TYPE));
+            getLuftdatenDataSample(Country.NL.toString(), SUPPORTED_SENSOR_TYPE, SUPPORTED_VALUE_TYPE),
+            getLuftdatenDataSample("XX", SUPPORTED_SENSOR_TYPE, SUPPORTED_VALUE_TYPE),
+            getLuftdatenDataSample(Country.PL.toString(), SUPPORTED_SENSOR_TYPE, SUPPORTED_VALUE_TYPE));
 
         // When
         final List<Measurement> target = measurementMapper.fromDtos(source);
@@ -108,9 +108,9 @@ class MeasurementMapperTest {
     void ignoreUnsupportedSensorType() {
         // Given
         List<LuftdatenMeasurement> source = Arrays.asList(
-                getLuftdatenDataSample(Country.CN.toString(), "some-unsupported", SUPPORTED_VALUE_TYPE),
-                getLuftdatenDataSample(Country.PL.toString(), SUPPORTED_SENSOR_TYPE, SUPPORTED_VALUE_TYPE),
-                getLuftdatenDataSample(Country.SE.toString(), SUPPORTED_SENSOR_TYPE, SUPPORTED_VALUE_TYPE));
+            getLuftdatenDataSample(Country.CN.toString(), "some-unsupported", SUPPORTED_VALUE_TYPE),
+            getLuftdatenDataSample(Country.PL.toString(), SUPPORTED_SENSOR_TYPE, SUPPORTED_VALUE_TYPE),
+            getLuftdatenDataSample(Country.SE.toString(), SUPPORTED_SENSOR_TYPE, SUPPORTED_VALUE_TYPE));
 
         // When
         final List<Measurement> target = measurementMapper.fromDtos(source);
@@ -129,9 +129,9 @@ class MeasurementMapperTest {
     void ignoreMeasurementSourceIfNoSupportedDataReads() {
         // Given
         List<LuftdatenMeasurement> source = Arrays.asList(
-                getLuftdatenDataSample(Country.CN.toString(), SUPPORTED_SENSOR_TYPE, "humidity"),
-                getLuftdatenDataSample(Country.PL.toString(), SUPPORTED_SENSOR_TYPE, SUPPORTED_VALUE_TYPE),
-                getLuftdatenDataSample(Country.SE.toString(), SUPPORTED_SENSOR_TYPE, SUPPORTED_VALUE_TYPE));
+            getLuftdatenDataSample(Country.CN.toString(), SUPPORTED_SENSOR_TYPE, "humidity"),
+            getLuftdatenDataSample(Country.PL.toString(), SUPPORTED_SENSOR_TYPE, SUPPORTED_VALUE_TYPE),
+            getLuftdatenDataSample(Country.SE.toString(), SUPPORTED_SENSOR_TYPE, SUPPORTED_VALUE_TYPE));
 
         // When
         final List<Measurement> target = measurementMapper.fromDtos(source);

--- a/backend/src/test/java/pl/itrack/airqeye/store/dataclient/luftdaten/mapper/MeasurementValueMapperTest.java
+++ b/backend/src/test/java/pl/itrack/airqeye/store/dataclient/luftdaten/mapper/MeasurementValueMapperTest.java
@@ -23,8 +23,8 @@ public class MeasurementValueMapperTest {
     public void takeDataForTypePm25() {
         // Given
         final SensorData sensorData = SensorData.builder()
-                .valueType(SENSOR_TYPE_PM25)
-                .value(SENSOR_VALUE).build();
+            .valueType(SENSOR_TYPE_PM25)
+            .value(SENSOR_VALUE).build();
 
         // When
         final List<MeasurementValue> convertedValues = mapper.fromDtos(Collections.singletonList(sensorData));
@@ -40,8 +40,8 @@ public class MeasurementValueMapperTest {
     public void takeDataForTypePm10() {
         // Given
         final SensorData sensorData = SensorData.builder()
-                .valueType(SENSOR_TYPE_PM10)
-                .value(SENSOR_VALUE).build();
+            .valueType(SENSOR_TYPE_PM10)
+            .value(SENSOR_VALUE).build();
 
         // When
         final List<MeasurementValue> convertedValues = mapper.fromDtos(Collections.singletonList(sensorData));
@@ -57,8 +57,8 @@ public class MeasurementValueMapperTest {
     public void ignoreDataForAnyOtherType() {
         // Given
         final SensorData sensorData = SensorData.builder()
-                .valueType("temperature")
-                .value(SENSOR_VALUE).build();
+            .valueType("temperature")
+            .value(SENSOR_VALUE).build();
 
         // When
         final List<MeasurementValue> convertedValues = mapper.fromDtos(Collections.singletonList(sensorData));
@@ -72,8 +72,8 @@ public class MeasurementValueMapperTest {
     public void doNotOverrideTechnicalStuff() {
         // Given
         final SensorData sensorData = SensorData.builder()
-                .valueType(SENSOR_TYPE_PM10)
-                .value(SENSOR_VALUE).build();
+            .valueType(SENSOR_TYPE_PM10)
+            .value(SENSOR_VALUE).build();
 
         // When
         final List<MeasurementValue> convertedValues = mapper.fromDtos(Collections.singletonList(sensorData));

--- a/backend/src/test/java/pl/itrack/airqeye/store/measurement/entity/MeasurementTest.java
+++ b/backend/src/test/java/pl/itrack/airqeye/store/measurement/entity/MeasurementTest.java
@@ -33,11 +33,11 @@ class MeasurementTest {
 
         // When
         final Measurement measurement = Measurement.builder()
-                .id(MEASUREMENT_ID)
-                .occurredAtUtc(OCCURRED_AT)
-                .measurementValues(asList(measurementValue1, measurementValue2))
-                .installation(installation)
-                .build();
+            .id(MEASUREMENT_ID)
+            .occurredAtUtc(OCCURRED_AT)
+            .measurementValues(asList(measurementValue1, measurementValue2))
+            .installation(installation)
+            .build();
 
         // Then
         assertThat(measurement.getOccurredAtUtc()).isEqualTo(OCCURRED_AT);
@@ -49,7 +49,7 @@ class MeasurementTest {
         assertThat(measurement.getMeasurementValues().get(0).getMeasurement().getId()).isEqualTo(MEASUREMENT_ID);
         assertThat(measurement.getMeasurementValues().get(1).getMeasurement().getId()).isEqualTo(MEASUREMENT_ID);
         assertThat(measurement.getMeasurementValues().stream().map(MeasurementValue::getValue))
-                .containsExactlyInAnyOrder(VALUE_1, VALUE_2);
+            .containsExactlyInAnyOrder(VALUE_1, VALUE_2);
     }
 
     @Test

--- a/backend/src/test/java/pl/itrack/airqeye/store/measurement/repository/InstallationRepositoryITest.java
+++ b/backend/src/test/java/pl/itrack/airqeye/store/measurement/repository/InstallationRepositoryITest.java
@@ -28,13 +28,13 @@ public class InstallationRepositoryITest {
     private static final long SUPPLIER_INSTALLATION_ID_3 = 3L;
 
     private static final LocalDateTime DATE_1
-            = LocalDateTime.of(9999, 9, 11, 2, 3, 5);
+        = LocalDateTime.of(9999, 9, 11, 2, 3, 5);
     private static final LocalDateTime DATE_2
-            = LocalDateTime.of(9999, 9, 13, 7, 11, 13);
+        = LocalDateTime.of(9999, 9, 13, 7, 11, 13);
     private static final LocalDateTime DATE_3
-            = LocalDateTime.of(9999, 9, 17, 17, 19, 23);
+        = LocalDateTime.of(9999, 9, 17, 17, 19, 23);
     private static final LocalDateTime DATE_4
-            = LocalDateTime.of(9999, 9, 19, 2, 3, 5);
+        = LocalDateTime.of(9999, 9, 19, 2, 3, 5);
 
     @Autowired
     private InstallationRepository repository;
@@ -89,7 +89,7 @@ public class InstallationRepositoryITest {
         assertThat(result).isNotEmpty();
         assertThat(result).isPresent();
         assertThat(result).hasValueSatisfying(value ->
-                assertThat(value.getSupplierInstallationId()).isEqualTo(SUPPLIER_INSTALLATION_ID_2));
+            assertThat(value.getSupplierInstallationId()).isEqualTo(SUPPLIER_INSTALLATION_ID_2));
     }
 
     @Test

--- a/backend/src/test/java/pl/itrack/airqeye/store/measurement/service/MeasurementServiceTest.java
+++ b/backend/src/test/java/pl/itrack/airqeye/store/measurement/service/MeasurementServiceTest.java
@@ -13,7 +13,6 @@ import pl.itrack.airqeye.store.measurement.enumeration.Supplier;
 import pl.itrack.airqeye.store.measurement.repository.InstallationRepository;
 
 import java.time.LocalDateTime;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -74,7 +73,7 @@ public class MeasurementServiceTest {
         // Given
         final List<Measurement> measurements = singletonList(Measurement.builder().id(1L).build());
         final Optional<Installation> installation = Optional.of(Installation.builder()
-                .supplierInstallationId(INSTALLATION_ID).measurements(measurements).build());
+            .supplierInstallationId(INSTALLATION_ID).measurements(measurements).build());
         when(installationRepository.findByProvider(eq(Supplier.LUFTDATEN), eq(INSTALLATION_ID))).thenReturn(installation);
 
         // When
@@ -88,11 +87,11 @@ public class MeasurementServiceTest {
     public void throwErrorIfSpecifiedInstallationNotFound() {
         // When
         final Throwable expectedError = catchThrowable(() ->
-                measurementService.retrieveMeasurements(NOT_EXISTING_INSTALLATION_ID, Supplier.LUFTDATEN));
+            measurementService.retrieveMeasurements(NOT_EXISTING_INSTALLATION_ID, Supplier.LUFTDATEN));
 
         // Then
         assertThat(expectedError).isInstanceOf(InstallationNotFoundException.class)
-                .hasMessageContaining(String.format(NOT_EXISTING_INSTALLATION_MESSAGE, NOT_EXISTING_INSTALLATION_ID));
+            .hasMessageContaining(String.format(NOT_EXISTING_INSTALLATION_MESSAGE, NOT_EXISTING_INSTALLATION_ID));
     }
 
     @Test
@@ -116,7 +115,7 @@ public class MeasurementServiceTest {
         final Installation unpersistedInstallation = buildInstallationWithMeasurementOfId(null);
         final Installation persistedInstallation = buildInstallationWithMeasurementOfId(1L);
         when(installationRepository.saveAll(eq(singletonList(unpersistedInstallation))))
-                .thenReturn(singletonList(persistedInstallation));
+            .thenReturn(singletonList(persistedInstallation));
 
         // When
         final List<Installation> result = measurementService.persist(unpersistedInstallation.getMeasurements());

--- a/backend/src/test/java/pl/itrack/airqeye/store/shared/LoadDatabase.java
+++ b/backend/src/test/java/pl/itrack/airqeye/store/shared/LoadDatabase.java
@@ -23,9 +23,9 @@ public class LoadDatabase {
         // as while the measurement constructing, JPA reference is set. We used to add new measurements
         // to the existing installation and then all references (related to bidirectional association) are updated.
         final Measurement measurement =
-                prebuildMeasurement(LocalDateTime.now().minusYears(5))
-                        .installation(prebuildInstallation(Supplier.LUFTDATEN).build())
-                        .build();
+            prebuildMeasurement(LocalDateTime.now().minusYears(5))
+                .installation(prebuildInstallation(Supplier.LUFTDATEN).build())
+                .build();
         return args -> log.info("Preloading " + installationRepository.save(measurement.getInstallation()));
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -626,6 +626,116 @@
         "remark-message-control": "^4.0.0"
       }
     },
+    "remark-lint-blockquote-indentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-blockquote-indentation/-/remark-lint-blockquote-indentation-1.0.3.tgz",
+      "integrity": "sha512-qK4C1l2VmeOVWEAkDYP0CaDtSFoaEBEo5l4oyz1kTkY7YB0Jh7llW2KjuhJz5IzMLmloKJzIyGwlu/odcwaHpg==",
+      "requires": {
+        "mdast-util-to-string": "^1.0.2",
+        "plur": "^3.0.0",
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-checkbox-character-style": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-checkbox-character-style/-/remark-lint-checkbox-character-style-1.0.3.tgz",
+      "integrity": "sha512-bQGrGHLlguTxOzuywHtYxNcg58TYhNgeEAMCTvdAggt5bYZIwmh/otx51JsQ0a96qxd/6/G0Ri2xzgyxf9wB8w==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1",
+        "vfile-location": "^2.0.1"
+      }
+    },
+    "remark-lint-code-block-style": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-code-block-style/-/remark-lint-code-block-style-1.0.3.tgz",
+      "integrity": "sha512-DL+rudnd9ILP5YXm74tLpMzfWZLqziX7NwIwUhqRefaOyWwxgPPy7hbT59FJqcFc6E/zvDz+Oq4nR1BSV5kEdw==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-definition-case": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/remark-lint-definition-case/-/remark-lint-definition-case-1.0.4.tgz",
+      "integrity": "sha512-ebl8vYOab9iy1Mr29Wo/9CmqcYGRjCfBievIZts08efrxIElWz+jB8/n7C17fh8k0djiiS/Of6W+bfRD+kMXLA==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.4.0"
+      }
+    },
+    "remark-lint-definition-spacing": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/remark-lint-definition-spacing/-/remark-lint-definition-spacing-1.0.4.tgz",
+      "integrity": "sha512-UderghITmru72OXB5ErCFhVsY7up2wK/m1bUD3E2dm/TFn73/7WpykENt5UirCDT/aeyoHYl8QXUVL20rAc3XQ==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.4.0"
+      }
+    },
+    "remark-lint-emphasis-marker": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-emphasis-marker/-/remark-lint-emphasis-marker-1.0.3.tgz",
+      "integrity": "sha512-ea2tEVyhZvYxwj6AHsW2qzgEDLljcnzq5taZ3FJFL0KMZYZHfWaIU90H43jrW4seGEtmaP1bmoqJaTavJ2x5Jw==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-fenced-code-flag": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-fenced-code-flag/-/remark-lint-fenced-code-flag-1.0.3.tgz",
+      "integrity": "sha512-X8Oi6dhfqV9NI3cVg29myvT/NATDHVgRGCpnNz76w7VXwzhBvQtJr1MxZzuPxfWLox+ARCXF2rY9n9hbYFHYTg==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-fenced-code-marker": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-fenced-code-marker/-/remark-lint-fenced-code-marker-1.0.3.tgz",
+      "integrity": "sha512-JKnojSQ8JkwpIpbNm6wtKEfx8iiv8QIwNHFM06iTCHExMhXa4pJ3wb5M5f0wsWNHtoND3lrw6AcVPoZxEPnflg==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-file-extension": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-file-extension/-/remark-lint-file-extension-1.0.3.tgz",
+      "integrity": "sha512-P5gzsxKmuAVPN7Kq1W0f8Ss0cFKfu+OlezYJWXf+5qOa+9Y5GqHEUOobPnsmNFZrVMiM7JoqJN2C9ZjrUx3N6Q==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0"
+      }
+    },
+    "remark-lint-final-definition": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-final-definition/-/remark-lint-final-definition-1.0.3.tgz",
+      "integrity": "sha512-QhbBYy99enfQDeUTElioCHrhgg+SgjMNRlru7/JlOguOufP6wn7AXgn2EVTrLZRoByY0VsNS2jCayXxUTzQ8KA==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
     "remark-lint-final-newline": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/remark-lint-final-newline/-/remark-lint-final-newline-1.0.3.tgz",
@@ -645,10 +755,55 @@
         "unist-util-visit": "^1.1.1"
       }
     },
+    "remark-lint-heading-increment": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-heading-increment/-/remark-lint-heading-increment-1.0.3.tgz",
+      "integrity": "sha512-/KL4/7D2pNxP07KKgktjcIUS+ga8pYI2k9Q/V91pMfyfSC+RYuCGOLFVJSKV0Affr/4Eqnfhw+gJ9X2HAanNuw==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-heading-style": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-heading-style/-/remark-lint-heading-style-1.0.3.tgz",
+      "integrity": "sha512-ZUhMav0HHUxo5gzLqxQsOf2ZpP/I3m6EEK8q25/kqpCYnwm1uRJ5CQ40PDQx46pmKtVibIMzDmraYovxNG3ovw==",
+      "requires": {
+        "mdast-util-heading-style": "^1.0.2",
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-link-title-style": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/remark-lint-link-title-style/-/remark-lint-link-title-style-1.0.4.tgz",
+      "integrity": "sha512-61/uH3zDTiozLJqgxp6rHGnVKTChC3UjL3Q0KQDBpprEOL4qLYjTn4fFKscVz776d0uUX6jczrW+GT4AFVOUgg==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1",
+        "vfile-location": "^2.0.1"
+      }
+    },
     "remark-lint-list-item-bullet-indent": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/remark-lint-list-item-bullet-indent/-/remark-lint-list-item-bullet-indent-1.0.3.tgz",
       "integrity": "sha512-iVxQbrgzLpMHG3C6o6wRta/+Bc96etOiBYJnh2zm/aWz6DJ7cGLDykngblP/C4he7LYSeWOD/8Y57HbXZwM2Og==",
+      "requires": {
+        "plur": "^3.0.0",
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-list-item-content-indent": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-list-item-content-indent/-/remark-lint-list-item-content-indent-1.0.3.tgz",
+      "integrity": "sha512-ZSIGJG2/6jd1xj/xEoDlkcJBf2Ksw8U6vIGJO0IFIA3BLCbJm2EMWJxto2cfzRvXoACmAaxTJMqW8qatPExa4w==",
       "requires": {
         "plur": "^3.0.0",
         "unified-lint-rule": "^1.0.0",
@@ -667,6 +822,39 @@
         "unist-util-generated": "^1.1.0",
         "unist-util-position": "^3.0.0",
         "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-list-item-spacing": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-list-item-spacing/-/remark-lint-list-item-spacing-1.1.3.tgz",
+      "integrity": "sha512-QzDY0Qfk6m+Az0kmxP57OfswIH1WRdd6SIpQLaUEgsTlsbrJOiO0sJYkkOlFPsyJIfp7SV/FCbr+aYCbHF+kRQ==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-maximum-heading-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-maximum-heading-length/-/remark-lint-maximum-heading-length-1.0.3.tgz",
+      "integrity": "sha512-ybcDpR5VHBjtjzdry7AdSjLFwslPo6rdhIJK2+WfHgfeEjIYnlz1uMvp1Z98QMmjpB5JSN83Kzg5fH8/B7poUw==",
+      "requires": {
+        "mdast-util-to-string": "^1.0.2",
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-maximum-line-length": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/remark-lint-maximum-line-length/-/remark-lint-maximum-line-length-1.2.1.tgz",
+      "integrity": "sha512-CSxX1qc+rAqixk8eBrI+yBsUmD8YGfOezFeJWjJRuUaoOvs67oqCIU+I2HbwcUYY8/KnDxF1MCp+uCM0RkjKKw==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.4.0"
       }
     },
     "remark-lint-no-auto-link-without-protocol": {
@@ -693,6 +881,18 @@
         "vfile-location": "^2.0.1"
       }
     },
+    "remark-lint-no-consecutive-blank-lines": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-consecutive-blank-lines/-/remark-lint-no-consecutive-blank-lines-1.0.3.tgz",
+      "integrity": "sha512-2Ef7fPxrfLditA7sTo2Qfqd+xwh/luWl8GzILE5vcWIxLDqKk3dTLJkB5nP+7Cr4kqWJAwXnRkEDd77ehrRV3A==",
+      "requires": {
+        "plur": "^3.0.0",
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
     "remark-lint-no-duplicate-definitions": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/remark-lint-no-duplicate-definitions/-/remark-lint-no-duplicate-definitions-1.0.5.tgz",
@@ -705,6 +905,69 @@
         "unist-util-visit": "^1.4.0"
       }
     },
+    "remark-lint-no-duplicate-headings": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-duplicate-headings/-/remark-lint-no-duplicate-headings-1.0.4.tgz",
+      "integrity": "sha512-QuPw+VG502Ctpd/jBjnBYuRXTg0ToP3D+dd3TYds4TRcdgaEFYTZfQ5zjK6XrxLMg0Hn9/WpXr4UqTlV4YZupA==",
+      "requires": {
+        "mdast-util-to-string": "^1.0.2",
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-stringify-position": "^2.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-no-emphasis-as-heading": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-emphasis-as-heading/-/remark-lint-no-emphasis-as-heading-1.0.3.tgz",
+      "integrity": "sha512-HEmyeyKciUz95+CgpAH98RPR73jq5u5CZb2FOMSqgNl9B6FZXqVpq9F3txPqUw3nAqFYOAEnfiaoRgcqtioh0Q==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-no-file-name-articles": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-file-name-articles/-/remark-lint-no-file-name-articles-1.0.3.tgz",
+      "integrity": "sha512-YZDJDKUWZEmhrO6tHB0u0K0K2qJKxyg/kryr14OaRMvWLS62RgMn97sXPZ38XOSN7mOcCnl0k7/bClghJXx0sg==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0"
+      }
+    },
+    "remark-lint-no-file-name-consecutive-dashes": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-file-name-consecutive-dashes/-/remark-lint-no-file-name-consecutive-dashes-1.0.3.tgz",
+      "integrity": "sha512-7f4vyXn/ca5lAguWWC3eu5hi8oZ7etX7aQlnTSgQZeslnJCbVJm6V6prFJKAzrqbBzMicUXr5pZLBDoXyTvHHw==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0"
+      }
+    },
+    "remark-lint-no-file-name-irregular-characters": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-file-name-irregular-characters/-/remark-lint-no-file-name-irregular-characters-1.0.3.tgz",
+      "integrity": "sha512-b4xIy1Yi8qZpM2vnMN+6gEujagPGxUBAs1judv6xJQngkl5d5zT8VQZsYsTGHku4NWHjjh3b7vK5mr0/yp4JSg==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0"
+      }
+    },
+    "remark-lint-no-file-name-mixed-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-file-name-mixed-case/-/remark-lint-no-file-name-mixed-case-1.0.3.tgz",
+      "integrity": "sha512-d7rJ4c8CzDbEbGafw2lllOY8k7pvnsO77t8cV4PHFylwQ3hmCdTHLuDvK87G3DaWCeKclp0PMyamfOgJWKMkPA==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0"
+      }
+    },
+    "remark-lint-no-file-name-outer-dashes": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-file-name-outer-dashes/-/remark-lint-no-file-name-outer-dashes-1.0.4.tgz",
+      "integrity": "sha512-+bZvvme2Bm3Vp5L2iKuvGHYVmHKrTkkRt8JqJPGepuhvBvT4Q7+CgfKyMtC/hIjyl+IcuJQ2H0qPRzdicjy1wQ==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0"
+      }
+    },
     "remark-lint-no-heading-content-indent": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/remark-lint-no-heading-content-indent/-/remark-lint-no-heading-content-indent-1.0.3.tgz",
@@ -715,6 +978,17 @@
         "unified-lint-rule": "^1.0.0",
         "unist-util-generated": "^1.1.0",
         "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-no-heading-punctuation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-heading-punctuation/-/remark-lint-no-heading-punctuation-1.0.3.tgz",
+      "integrity": "sha512-JQD05RjLS99ePBQ4Bed1uWsQTlIMBTcGgIgF6jFXSCEqhwnrIUDwk6S3MG1RZsKd3TLw2xuT/i+POpfBc2+1kQ==",
+      "requires": {
+        "mdast-util-to-string": "^1.0.2",
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
         "unist-util-visit": "^1.1.1"
       }
     },
@@ -741,6 +1015,28 @@
         "unist-util-visit": "^1.1.1"
       }
     },
+    "remark-lint-no-multiple-toplevel-headings": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-multiple-toplevel-headings/-/remark-lint-no-multiple-toplevel-headings-1.0.4.tgz",
+      "integrity": "sha512-0wDddx6htN5sL9/rofesiQF0oEgwN5224UmueiDx0ZUlYrn6VS0/SS0X3WWxtXmyeqlExfWF3D/g89tNs7dcjw==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-stringify-position": "^2.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-no-shell-dollars": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-shell-dollars/-/remark-lint-no-shell-dollars-1.0.3.tgz",
+      "integrity": "sha512-fT3lQMTjEkPryL+63qDP1NfrohP3tG5i3SkNWSSR4VLU6OSsSSXlHGQGjo0ag//+EPKHB5/9frB/YQ0gDEPRGQ==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
     "remark-lint-no-shortcut-reference-image": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/remark-lint-no-shortcut-reference-image/-/remark-lint-no-shortcut-reference-image-1.0.3.tgz",
@@ -759,6 +1055,17 @@
         "unified-lint-rule": "^1.0.0",
         "unist-util-generated": "^1.1.0",
         "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-no-table-indentation": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-table-indentation/-/remark-lint-no-table-indentation-1.0.4.tgz",
+      "integrity": "sha512-H4VGHcg1k8sTIbwazFYLNbDqpPR+M0aHHKDf+93b/xyd27Dp0ODQrMnQbls1Cls5qOAQnwAQbx+75wcpFxP3OQ==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.4.0"
       }
     },
     "remark-lint-no-undefined-references": {
@@ -786,6 +1093,83 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/remark-lint-ordered-list-marker-style/-/remark-lint-ordered-list-marker-style-1.0.3.tgz",
       "integrity": "sha512-24TmW1eUa/2JlwprZg9jJ8LKLxNGKnlKiI5YOhN4taUp2yv8daqlV9vR54yfn/ZZQh6EQvbIX0jeVY9NYgQUtw==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-ordered-list-marker-value": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-ordered-list-marker-value/-/remark-lint-ordered-list-marker-value-1.0.3.tgz",
+      "integrity": "sha512-WQ9yLD8cI9DSk/CE+APKUT6ZeXp0/RzOnsYqzMxEa8n1QHSqRSF7hVEiisqNTG9+gV64OEE66e+m4c7RVSUADw==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-rule-style": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-rule-style/-/remark-lint-rule-style-1.0.3.tgz",
+      "integrity": "sha512-SJe7IFORYRdo8JUhMSdcTktVAUVNVp36YYl1ZD9CfHqQHWlFD+3vWYzJXOZfog/i+CyWf7Yi0WVYmQes+167dA==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-strong-marker": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-strong-marker/-/remark-lint-strong-marker-1.0.3.tgz",
+      "integrity": "sha512-PFkH282dCwfRsVEw9IxbYbaZBY4UcTuT2SN+lA3R0cBeocWnOySVw8YEm4sv9JfV8BLcQA5gc4tj66/U3KCScw==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-table-cell-padding": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/remark-lint-table-cell-padding/-/remark-lint-table-cell-padding-1.0.4.tgz",
+      "integrity": "sha512-AQWWtV1yca1PN27QaFRJbBK6Ro/bopv1XnVKxj/iMebhOU2D2FBJ8rXmMZXVMC3G9OB2WSzGgqH3nP6QY12LoA==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.4.0"
+      }
+    },
+    "remark-lint-table-pipe-alignment": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-table-pipe-alignment/-/remark-lint-table-pipe-alignment-1.0.3.tgz",
+      "integrity": "sha512-5fhEMcKqNjK6S/y7cVG0+iVqhmhXFW+awIuN7vOBhmDbZ3HF9rCCy20XiHoaG6FzrPJ+zfkjK/QZAbq2Vf58HA==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-table-pipes": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-table-pipes/-/remark-lint-table-pipes-1.0.3.tgz",
+      "integrity": "sha512-K9NnGZp6i0m/CaOH7ZT4Ymt2seyiRPcBIlNMMGXBm6gpy34KJDDxYqsNUrh+j7dR+Zg4rYAQLnr3BiSHvj+rbQ==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-unordered-list-marker-style": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-unordered-list-marker-style/-/remark-lint-unordered-list-marker-style-1.0.3.tgz",
+      "integrity": "sha512-0nn/Yscy5ImO4fqByrk/Ua02UwGx8LRu+0kdCbkVz4IxPO5qxTEfyccUQZR71zTdMJp1d2OeqyD9XtMaO4X7Ww==",
       "requires": {
         "unified-lint-rule": "^1.0.0",
         "unist-util-generated": "^1.1.0",
@@ -823,6 +1207,78 @@
         "unist-util-remove-position": "^1.0.0",
         "vfile-location": "^2.0.0",
         "xtend": "^4.0.1"
+      }
+    },
+    "remark-preset-lint-consistent": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/remark-preset-lint-consistent/-/remark-preset-lint-consistent-2.0.3.tgz",
+      "integrity": "sha512-mrtGznAikgXvBwgQdkT3LAWn47wQGvFs9IsLuBjNluv9JnCqkt2CpOG5htlES5aB3YnVdxzSS7AntF5iNxSlpA==",
+      "requires": {
+        "remark-lint": "^6.0.0",
+        "remark-lint-blockquote-indentation": "^1.0.0",
+        "remark-lint-checkbox-character-style": "^1.0.0",
+        "remark-lint-code-block-style": "^1.0.0",
+        "remark-lint-emphasis-marker": "^1.0.0",
+        "remark-lint-fenced-code-marker": "^1.0.0",
+        "remark-lint-heading-style": "^1.0.0",
+        "remark-lint-link-title-style": "^1.0.0",
+        "remark-lint-list-item-content-indent": "^1.0.0",
+        "remark-lint-ordered-list-marker-style": "^1.0.0",
+        "remark-lint-rule-style": "^1.0.0",
+        "remark-lint-strong-marker": "^1.0.0",
+        "remark-lint-table-cell-padding": "^1.0.0"
+      }
+    },
+    "remark-preset-lint-markdown-style-guide": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/remark-preset-lint-markdown-style-guide/-/remark-preset-lint-markdown-style-guide-2.1.3.tgz",
+      "integrity": "sha512-H/jSoLvTY8abUcB+7/062I2oHevlHcHdrfRMP2RMh19QA1wmARgNEn3tZfdBXFq1TpzhevGgb6VwSdOjdU8NOQ==",
+      "requires": {
+        "remark-lint": "^6.0.0",
+        "remark-lint-blockquote-indentation": "^1.0.0",
+        "remark-lint-code-block-style": "^1.0.0",
+        "remark-lint-definition-case": "^1.0.0",
+        "remark-lint-definition-spacing": "^1.0.0",
+        "remark-lint-emphasis-marker": "^1.0.0",
+        "remark-lint-fenced-code-flag": "^1.0.0",
+        "remark-lint-fenced-code-marker": "^1.0.0",
+        "remark-lint-file-extension": "^1.0.0",
+        "remark-lint-final-definition": "^1.0.0",
+        "remark-lint-hard-break-spaces": "^1.0.0",
+        "remark-lint-heading-increment": "^1.0.0",
+        "remark-lint-heading-style": "^1.0.0",
+        "remark-lint-link-title-style": "^1.0.0",
+        "remark-lint-list-item-content-indent": "^1.0.0",
+        "remark-lint-list-item-indent": "^1.0.0",
+        "remark-lint-list-item-spacing": "^1.0.0",
+        "remark-lint-maximum-heading-length": "^1.0.0",
+        "remark-lint-maximum-line-length": "^1.0.0",
+        "remark-lint-no-auto-link-without-protocol": "^1.0.0",
+        "remark-lint-no-blockquote-without-marker": "^2.0.0",
+        "remark-lint-no-consecutive-blank-lines": "^1.0.0",
+        "remark-lint-no-duplicate-headings": "^1.0.0",
+        "remark-lint-no-emphasis-as-heading": "^1.0.0",
+        "remark-lint-no-file-name-articles": "^1.0.0",
+        "remark-lint-no-file-name-consecutive-dashes": "^1.0.0",
+        "remark-lint-no-file-name-irregular-characters": "^1.0.0",
+        "remark-lint-no-file-name-mixed-case": "^1.0.0",
+        "remark-lint-no-file-name-outer-dashes": "^1.0.0",
+        "remark-lint-no-heading-punctuation": "^1.0.0",
+        "remark-lint-no-inline-padding": "^1.0.0",
+        "remark-lint-no-literal-urls": "^1.0.0",
+        "remark-lint-no-multiple-toplevel-headings": "^1.0.0",
+        "remark-lint-no-shell-dollars": "^1.0.0",
+        "remark-lint-no-shortcut-reference-image": "^1.0.0",
+        "remark-lint-no-shortcut-reference-link": "^1.0.0",
+        "remark-lint-no-table-indentation": "^1.0.0",
+        "remark-lint-ordered-list-marker-style": "^1.0.0",
+        "remark-lint-ordered-list-marker-value": "^1.0.0",
+        "remark-lint-rule-style": "^1.0.0",
+        "remark-lint-strong-marker": "^1.0.0",
+        "remark-lint-table-cell-padding": "^1.0.0",
+        "remark-lint-table-pipe-alignment": "^1.0.0",
+        "remark-lint-table-pipes": "^1.0.0",
+        "remark-lint-unordered-list-marker-style": "^1.0.0"
       }
     },
     "remark-preset-lint-recommended": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   "dependencies": {
     "remark-cli": "^7.0.0",
     "remark-lint": "^6.0.5",
+    "remark-preset-lint-consistent": "^2.0.3",
+    "remark-preset-lint-markdown-style-guide": "^2.1.3",
     "remark-preset-lint-recommended": "^3.0.3"
   }
 }


### PR DESCRIPTION
Added editor config for code formatting standardization
and reformatted the existing code.
Activated Markdown related presets:

* remark-preset-lint-consistent — rules that enforce consistency
* remark-preset-lint-markdown-style-guide — rules that enforce the
  markdown style guide
* remark-preset-lint-recommended — rules that prevent mistakes
  or syntaxes that do not work correctly across vendors